### PR TITLE
Add proper cache busting, close #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 bower_components
-dist
 secrets.json
 .tmp
 .DS_Store
+build

--- a/Assemblefile.js
+++ b/Assemblefile.js
@@ -25,6 +25,7 @@ var assemble = require('assemble'),
     reload = browserSync.reload,
     config = require('./config.js'),
     buildDir = config.pkg.config.buildDir,
+    deployDir = config.pkg.config.deployDir,
     system = config.site.assemble.system,
     content = config.site.assemble.content,
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rsync -rltvzp --checksum --delete ~/projects/smaty.se/dist/* root@vps:/srv/web/smaty.se
+rsync -rltvzp --checksum --delete ~/projects/smaty.se/build/Release/* root@vps:/srv/web/smaty.se

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -13,7 +13,6 @@ assemble:
 site:
     title: Småty in the land
     titleSeparator: "||"
-    baseUrl: http://smaty.se
 
 navigation:
     index:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "version": "1.0.0",
   "config": {
-    "buildDir": "dist"
+    "buildDir": "build",
+    "deployDir": "build/Release"
   },
   "devDependencies": {
     "assemble": "git://github.com/assemble/assemble.git#v0.6.0",
@@ -42,6 +43,7 @@
     "gulp-pleeease": "^1.2.0",
     "gulp-rename": "^1.2.0",
     "gulp-rev": "^3.0.1",
+    "gulp-rev-all": "^0.7.6",
     "gulp-rev-collector": "^0.1.4",
     "gulp-rev-css-url": "0.0.11",
     "gulp-robots": "^1.1.2",
@@ -82,8 +84,10 @@
     "github": "watson --update --format silent",
     "gh": "./node_modules/gh/bin/gh.js",
     "postinstall": "bower install && bundle install",
-    "predeploy": "npm run assemble clean && export NODE_ENV=production; npm run assemble && gulp build && node lib/html-validator.js",
-    "deploy": "./bin/deploy",
-    "server": "cd dist && python -m SimpleHTTPServer 9000"
+    "predeploy": "export NODE_ENV=production; npm run build",
+    "deploy": "gulp cache-busting && ./bin/deploy",
+    "predrydeploy": "npm run predeploy",
+    "drydeploy": "gulp cache-busting",
+    "server": "cd build && python -m SimpleHTTPServer 9000"
   }
 }


### PR DESCRIPTION
While the prior combination of tasks didn't work, the current setup with
`gulp-rev-all` works.

To simplify other bits, the baseUrl was removed from site.yaml (it's in
package.json), and the buildDir was moved to `build`. The deployDir
is `build/Release`.
